### PR TITLE
Fix accurate metrics report

### DIFF
--- a/crash-handler-process/main.cpp
+++ b/crash-handler-process/main.cpp
@@ -236,15 +236,15 @@ void checkProcesses(std::mutex* m) {
 		if (!alive) {
 			index--;
 			bool criticalProcessAlive = false;
-			long long criticalProcessDeathTime = 0;
-			long long normalProcessFirstDeathTime = 0;
+			uint64_t criticalProcessDeathTime = 0;
+			uint64_t normalProcessFirstDeathTime = -1; // Start with a huge number to proper retrieve the lowest one
 			for (size_t i = 0; i < processes.size(); i++) {
 				if (processes.at(i)->getCritical()) {
 					criticalProcessAlive = processes.at(i)->getAlive();
 					criticalProcessDeathTime = processes.at(i)->getStopTime();
 				}
 				else {
-					normalProcessFirstDeathTime = std::max(criticalProcessDeathTime = processes.at(i)->getStopTime(), normalProcessFirstDeathTime);
+					normalProcessFirstDeathTime = std::min(processes.at(i)->getStopTime(), normalProcessFirstDeathTime);
 				}
 			}
 			if (!processes.at(index)->getCritical() && criticalProcessAlive) {

--- a/crash-handler-process/main.cpp
+++ b/crash-handler-process/main.cpp
@@ -237,7 +237,7 @@ void checkProcesses(std::mutex* m) {
 			index--;
 			bool criticalProcessAlive = false;
 			uint64_t criticalProcessDeathTime = 0;
-			uint64_t normalProcessFirstDeathTime = -1; // Start with a huge number to proper retrieve the lowest one
+			uint64_t normalProcessFirstDeathTime = UINT64_MAX;
 			for (size_t i = 0; i < processes.size(); i++) {
 				if (processes.at(i)->getCritical()) {
 					criticalProcessAlive = processes.at(i)->getAlive();
@@ -288,12 +288,15 @@ void checkProcesses(std::mutex* m) {
 
 			// Metrics
 			if (normalProcessFirstDeathTime > criticalProcessDeathTime) {
+				std::cout << "Frontend will be blamed" << std::endl;
 				metricsServer.BlameFrontend();
 			}
 			else if (normalProcessFirstDeathTime < criticalProcessDeathTime) {
+				std::cout << "Backend will be blamed" << std::endl;
 				metricsServer.BlameServer();
 			}
 			else {
+				std::cout << "Can't verify process death times, checking if critical process is alive" << std::endl;
 				(!processes.at(index)->getCritical() && criticalProcessAlive) ? metricsServer.BlameFrontend() : metricsServer.BlameServer();
 			}
 

--- a/crash-handler-process/main.cpp
+++ b/crash-handler-process/main.cpp
@@ -28,6 +28,10 @@
 #include <windows.h>
 #include <psapi.h>
 
+// Undefine windows min and max
+#undef min
+#undef max
+
 VOID DisconnectAndReconnect(DWORD);
 BOOL ConnectToNewClient(HANDLE, LPOVERLAPPED);
 
@@ -232,14 +236,19 @@ void checkProcesses(std::mutex* m) {
 		if (!alive) {
 			index--;
 			bool criticalProcessAlive = false;
+			long long criticalProcessDeathTime = 0;
+			long long normalProcessFirstDeathTime = 0;
 			for (size_t i = 0; i < processes.size(); i++) {
-				if (processes.at(i)->getCritical())
+				if (processes.at(i)->getCritical()) {
 					criticalProcessAlive = processes.at(i)->getAlive();
+					criticalProcessDeathTime = processes.at(i)->getStopTime();
+				}
+				else {
+					normalProcessFirstDeathTime = std::max(criticalProcessDeathTime = processes.at(i)->getStopTime(), normalProcessFirstDeathTime);
+				}
 			}
 			if (!processes.at(index)->getCritical() && criticalProcessAlive) {
 				log_error << "checkProcesses critical process alive" << std::endl;
-				// Metrics
-				metricsServer.BlameFrontend();
 
 				int code = MessageBox(
 					NULL,
@@ -271,16 +280,23 @@ void checkProcesses(std::mutex* m) {
 					break;
 				}
 				terminalCriticalProcesses();
-				closeAll = true;
+
 				log_debug << "checkProcesses critical process ended" << std::endl;
 			}
-			else {
 
-				// Metrics
-				metricsServer.BlameServer();
+			closeAll = true;
 
-				closeAll = true;
+			// Metrics
+			if (normalProcessFirstDeathTime > criticalProcessDeathTime) {
+				metricsServer.BlameFrontend();
 			}
+			else if (normalProcessFirstDeathTime < criticalProcessDeathTime) {
+				metricsServer.BlameServer();
+			}
+			else {
+				(!processes.at(index)->getCritical() && criticalProcessAlive) ? metricsServer.BlameFrontend() : metricsServer.BlameServer();
+			}
+
 			*exitApp = true;
 		}
 		else {

--- a/crash-handler-process/process.cpp
+++ b/crash-handler-process/process.cpp
@@ -73,11 +73,16 @@ void Process::setAlive(bool isAlive) {
 }
 
 void Process::stopWorker() {
+	m_stopTime = std::chrono::system_clock::now().time_since_epoch().count();
 	m_stop = true;
 }
 
 bool Process::getStopped(void) {
 	return m_stop;
+}
+
+long long Process::getStopTime(void) {
+	return m_stopTime;
 }
 
 std::thread* Process::getWorker(void) {

--- a/crash-handler-process/process.cpp
+++ b/crash-handler-process/process.cpp
@@ -73,7 +73,7 @@ void Process::setAlive(bool isAlive) {
 }
 
 void Process::stopWorker() {
-	m_stopTime = std::chrono::system_clock::now().time_since_epoch().count();
+	m_stopTime = static_cast<uint64_t>(std::chrono::system_clock::now().time_since_epoch().count());
 	m_stop = true;
 }
 
@@ -81,7 +81,7 @@ bool Process::getStopped(void) {
 	return m_stop;
 }
 
-long long Process::getStopTime(void) {
+uint64_t Process::getStopTime(void) {
 	return m_stopTime;
 }
 

--- a/crash-handler-process/process.hpp
+++ b/crash-handler-process/process.hpp
@@ -27,6 +27,7 @@ private:
 	std::thread* m_worker;
 	bool m_isAlive;
 	bool m_stop;
+	long long m_stopTime = 0;
 	std::string m_name;
 	HANDLE m_hdl;
 
@@ -40,6 +41,7 @@ public:
 	bool getAlive(void);
 	void setAlive(bool isAlive);
 	bool getStopped(void);
+	long long getStopTime(void);
 	std::thread* getWorker(void);
 	HANDLE getHandle(void);
 

--- a/crash-handler-process/process.hpp
+++ b/crash-handler-process/process.hpp
@@ -27,7 +27,7 @@ private:
 	std::thread* m_worker;
 	bool m_isAlive;
 	bool m_stop;
-	long long m_stopTime = 0;
+	uint64_t m_stopTime = 0;
 	std::string m_name;
 	HANDLE m_hdl;
 
@@ -41,7 +41,7 @@ public:
 	bool getAlive(void);
 	void setAlive(bool isAlive);
 	bool getStopped(void);
-	long long getStopTime(void);
+    uint64_t getStopTime(void);
 	std::thread* getWorker(void);
 	HANDLE getHandle(void);
 


### PR DESCRIPTION
Register the death time when a process dies and uses this time to determine the first process that crashed.

This is necessary since our worker thread runs every 1 second and it could miss processes dying, in the end blaming the first one who was checked by its internal loop who returned true on `getStopped()`.