### PR TITLE
[WIP] Fix wrong blaming

### DIFF
--- a/crash-handler-process/main.cpp
+++ b/crash-handler-process/main.cpp
@@ -13,6 +13,10 @@
 #include <windows.h>
 #include <psapi.h>
 
+// Undefine windows min and max
+#undef min
+#undef max
+
 VOID DisconnectAndReconnect(DWORD);
 BOOL ConnectToNewClient(HANDLE, LPOVERLAPPED);
 
@@ -215,14 +219,19 @@ void checkProcesses(std::mutex* m) {
 		if (!alive) {
 			index--;
 			bool criticalProcessAlive = false;
+			long long criticalProcessDeathTime = 0;
+			long long normalProcessFirstDeathTime = 0;
 			for (size_t i = 0; i < processes.size(); i++) {
-				if (processes.at(i)->getCritical())
+				if (processes.at(i)->getCritical()) {
 					criticalProcessAlive = processes.at(i)->getAlive();
+					criticalProcessDeathTime = processes.at(i)->getStopTime();
+				}
+				else {
+					normalProcessFirstDeathTime = std::max(criticalProcessDeathTime = processes.at(i)->getStopTime(), normalProcessFirstDeathTime);
+				}
 			}
-			if (!processes.at(index)->getCritical() && criticalProcessAlive) {
 
-				// Metrics
-				metricsServer.BlameFrontend();
+			if (!processes.at(index)->getCritical() && criticalProcessAlive) {
 
 				int code = MessageBox(
 					NULL,
@@ -254,15 +263,21 @@ void checkProcesses(std::mutex* m) {
 					break;
 				}
 				terminalCriticalProcesses();
-				closeAll = true;
+			}
+
+			closeAll = true;
+
+			// Metrics
+			if (normalProcessFirstDeathTime > criticalProcessDeathTime) {
+				metricsServer.BlameFrontend();
+			}
+			else if (normalProcessFirstDeathTime < criticalProcessDeathTime) {
+				metricsServer.BlameServer();
 			}
 			else {
-
-				// Metrics
-				metricsServer.BlameServer();
-
-				closeAll = true;
+				(!processes.at(index)->getCritical() && criticalProcessAlive) ? metricsServer.BlameFrontend() : metricsServer.BlameServer();
 			}
+
 			*exitApp = true;
 		}
 		else {

--- a/crash-handler-process/main.cpp
+++ b/crash-handler-process/main.cpp
@@ -220,7 +220,7 @@ void checkProcesses(std::mutex* m) {
 			index--;
 			bool criticalProcessAlive = false;
 			uint64_t criticalProcessDeathTime = 0;
-			uint64_t normalProcessFirstDeathTime = -1; // Start with a huge number to proper retrieve the lowest one
+			uint64_t normalProcessFirstDeathTime = UINT64_MAX;
 			for (size_t i = 0; i < processes.size(); i++) {
 				if (processes.at(i)->getCritical()) {
 					criticalProcessAlive = processes.at(i)->getAlive();
@@ -269,12 +269,15 @@ void checkProcesses(std::mutex* m) {
 
 			// Metrics
 			if (normalProcessFirstDeathTime > criticalProcessDeathTime) {
+				std::cout << "Frontend will be blamed" << std::endl;
 				metricsServer.BlameFrontend();
 			}
 			else if (normalProcessFirstDeathTime < criticalProcessDeathTime) {
+				std::cout << "Backend will be blamed" << std::endl;
 				metricsServer.BlameServer();
 			}
 			else {
+				std::cout << "Can't verify process death times, checking if critical process is alive" << std::endl;
 				(!processes.at(index)->getCritical() && criticalProcessAlive) ? metricsServer.BlameFrontend() : metricsServer.BlameServer();
 			}
 

--- a/crash-handler-process/main.cpp
+++ b/crash-handler-process/main.cpp
@@ -219,15 +219,15 @@ void checkProcesses(std::mutex* m) {
 		if (!alive) {
 			index--;
 			bool criticalProcessAlive = false;
-			long long criticalProcessDeathTime = 0;
-			long long normalProcessFirstDeathTime = 0;
+			uint64_t criticalProcessDeathTime = 0;
+			uint64_t normalProcessFirstDeathTime = -1; // Start with a huge number to proper retrieve the lowest one
 			for (size_t i = 0; i < processes.size(); i++) {
 				if (processes.at(i)->getCritical()) {
 					criticalProcessAlive = processes.at(i)->getAlive();
 					criticalProcessDeathTime = processes.at(i)->getStopTime();
 				}
 				else {
-					normalProcessFirstDeathTime = std::max(criticalProcessDeathTime = processes.at(i)->getStopTime(), normalProcessFirstDeathTime);
+					normalProcessFirstDeathTime = std::min(processes.at(i)->getStopTime(), normalProcessFirstDeathTime);
 				}
 			}
 

--- a/crash-handler-process/metricsprovider.cpp
+++ b/crash-handler-process/metricsprovider.cpp
@@ -300,15 +300,26 @@ void MetricsProvider::StartPollingEvent()
             else if (message.type == MessageType::Pid)
             {
                 m_ServerPid = *reinterpret_cast<DWORD*>(message.param1);
+
+                // Now that we received the pid from the server, if we don't receive any other message
+                // from it and a crash happens, we should blame the backend and not the frontend anymore
+
+                // Check if server pid is valid and the server is active
+                if (!ServerIsActive()) {
+
+                    // This is more for debug purposes, the pid received should always be valid and
+                    // if there is a considerable amount of occurrences of invalid pid it will require
+                    // future treatment
+                    m_LastStatus = "Invalid Server Pid";
+                }
+                else {
+                    m_LastStatus = "Backend Crash";
+                }
             }
 
             else if (message.type == MessageType::Tag)
             {
-                m_ReportTags.insert({std::string(message.param1), std::string(message.param2)});
-
-                // Now that we received the tag from the server, if we don't receive any other message
-                // from it and a crash happens, we should blame the backend and not the frontend anymore
-                m_LastStatus = "Backend Crash";
+                m_ReportTags.insert({ std::string(message.param1), std::string(message.param2) });
             }
         }
     });

--- a/crash-handler-process/metricsprovider.cpp
+++ b/crash-handler-process/metricsprovider.cpp
@@ -311,6 +311,14 @@ void MetricsProvider::StartPollingEvent()
                     // if there is a considerable amount of occurrences of invalid pid it will require
                     // future treatment
                     m_LastStatus = "Invalid Server Pid";
+
+					// Set the server as if it exited successfully since we wouldn't be able to keep
+					// track of it on shutdown, if the pid is invalid we won't wait for the server
+					// shutdown message and this could cause an invalid blame to the server
+					// By setting this to true we guarantee that the Shutdown() will be called in 
+					// that case, so shutdown crashes won't be reported, other then that it will
+					// work as intended
+					m_ServerExitedSuccessfully = true;
                 }
                 else {
                     m_LastStatus = "Backend Crash";

--- a/crash-handler-process/namedsocket-win.cpp
+++ b/crash-handler-process/namedsocket-win.cpp
@@ -276,7 +276,7 @@ bool NamedSocket_win::read(std::vector<Process*>* processes, std::mutex* mu, boo
 		if (Pipe[i].cbRead > 0) {
 			Pipe[i].fPendingIO = FALSE;
 
-            processRequest(Pipe[i].chRequest, processes, mu, exit);
+			processRequest(Pipe[i].chRequest, processes, mu, exit);
 		}
 		dwErr = GetLastError();
 		if (!fSuccess && (dwErr == ERROR_IO_PENDING))

--- a/crash-handler-process/namedsocket-win.cpp
+++ b/crash-handler-process/namedsocket-win.cpp
@@ -211,7 +211,7 @@ bool NamedSocket_win::read(std::vector<Process*>* processes, std::mutex* mu, boo
 		INSTANCES,
 		hEvents,
 		FALSE,
-		500);
+		1000);
 
 	i = dwWait - WAIT_OBJECT_0;  // get current pipe
 	if (i < 0 || i >(INSTANCES - 1))
@@ -276,8 +276,7 @@ bool NamedSocket_win::read(std::vector<Process*>* processes, std::mutex* mu, boo
 		if (Pipe[i].cbRead > 0) {
 			Pipe[i].fPendingIO = FALSE;
 
-			// Start thread here
-			requests.push_back(new std::thread(processRequest, Pipe[i].chRequest, processes, mu, exit));
+            processRequest(Pipe[i].chRequest, processes, mu, exit);
 		}
 		dwErr = GetLastError();
 		if (!fSuccess && (dwErr == ERROR_IO_PENDING))

--- a/crash-handler-process/process.cpp
+++ b/crash-handler-process/process.cpp
@@ -54,7 +54,7 @@ void Process::setAlive(bool isAlive) {
 }
 
 void Process::stopWorker() {
-	m_stopTime = std::chrono::system_clock::now().time_since_epoch().count();
+	m_stopTime = static_cast<uint64_t>(std::chrono::system_clock::now().time_since_epoch().count());
 	m_stop = true;
 }
 
@@ -62,7 +62,7 @@ bool Process::getStopped(void) {
 	return m_stop;
 }
 
-long long Process::getStopTime(void) {
+uint64_t Process::getStopTime(void) {
 	return m_stopTime;
 }
 

--- a/crash-handler-process/process.cpp
+++ b/crash-handler-process/process.cpp
@@ -54,11 +54,16 @@ void Process::setAlive(bool isAlive) {
 }
 
 void Process::stopWorker() {
+	m_stopTime = std::chrono::system_clock::now().time_since_epoch().count();
 	m_stop = true;
 }
 
 bool Process::getStopped(void) {
 	return m_stop;
+}
+
+long long Process::getStopTime(void) {
+	return m_stopTime;
 }
 
 std::thread* Process::getWorker(void) {

--- a/crash-handler-process/process.hpp
+++ b/crash-handler-process/process.hpp
@@ -13,6 +13,7 @@ private:
 	std::thread* m_worker;
 	bool m_isAlive;
 	bool m_stop;
+	long long m_stopTime = 0;
 	std::string m_name;
 	HANDLE m_hdl;
 
@@ -26,6 +27,7 @@ public:
 	bool getAlive(void);
 	void setAlive(bool isAlive);
 	bool getStopped(void);
+	long long getStopTime(void);
 	std::thread* getWorker(void);
 	HANDLE getHandle(void);
 

--- a/crash-handler-process/process.hpp
+++ b/crash-handler-process/process.hpp
@@ -13,7 +13,7 @@ private:
 	std::thread* m_worker;
 	bool m_isAlive;
 	bool m_stop;
-	long long m_stopTime = 0;
+	uint64_t m_stopTime = 0;
 	std::string m_name;
 	HANDLE m_hdl;
 
@@ -27,7 +27,7 @@ public:
 	bool getAlive(void);
 	void setAlive(bool isAlive);
 	bool getStopped(void);
-	long long getStopTime(void);
+    uint64_t getStopTime(void);
 	std::thread* getWorker(void);
 	HANDLE getHandle(void);
 

--- a/crash-handler-process/process.hpp
+++ b/crash-handler-process/process.hpp
@@ -27,7 +27,7 @@ public:
 	bool getAlive(void);
 	void setAlive(bool isAlive);
 	bool getStopped(void);
-    uint64_t getStopTime(void);
+	uint64_t getStopTime(void);
 	std::thread* getWorker(void);
 	HANDLE getHandle(void);
 


### PR DESCRIPTION
Fix the case where SLOBS correctly exited but the crash handler was still blaming it from crashing.

How it happened:
- Frontend call `obs.NodeObs.StopCrashHandler();` and continue exiting 
- Crash handler takes 1s on its internal loop to check if a process died, lets suppose one of the processes died during this period and it didn't processed the stop message since its asynchronous
- Crash handler will detect that one or more processed died and will interpret it as a crash
- Crash handler receives the stop message some time after, but it's late, it already counted as a crash

This PR also adds a death time variable for the processes to help identify what process died first (in case multiple of them are already dead when the metrics processing takes place).