### PR TITLE
Disable sending reports to Sentry

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,6 @@ build_script:
   - cmake --build %SLBuildDirectory% --target install --config RelWithDebInfo
   - tar cvaf "%DistributionAritfact%.tar.gz" -C "%FullDistributePath%\crash-handler" "crash-handler"
   
-before_deploy:
-  - ps: Push-AppveyorArtifact "$env:DistributionAritfact.tar.gz"
-
 deploy:
   - provider: GitHub
     artifact: $(DistributionAritfact).tar.gz
@@ -42,9 +39,5 @@ deploy:
     force_update: true
     on:
       appveyor_repo_tag: true
-
-artifacts:
-  - path: $(DistributionAritfact).tar.gz
-    name: Distribution Aritfact
 
 test: off

--- a/crash-handler-process/metricsprovider.cpp
+++ b/crash-handler-process/metricsprovider.cpp
@@ -443,7 +443,7 @@ void MetricsProvider::SendMetricsReport(std::string status)
 
     j["tags"] = tags;
 
-    curl.post(j, true).data;
+    // curl.post(j, true).data;
 }
 
 void MetricsProvider::MetricsFileSetStatus(std::string status)


### PR DESCRIPTION
In t he future we should send the metrics reports to our server instead Sentry.