### PR TITLE
Fix for node epipe error 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # crash-handler
 Crash handler
+

--- a/crash-handler-module/main.js
+++ b/crash-handler-module/main.js
@@ -9,18 +9,15 @@ function tryConnect(buffer, attempt = 5, waitMs = 100) {
   });
   socket.on('ready', () => {
     socket.write(buffer);
-    console.log('tryConnect ready for buffer ' + buffer.toString('hex'))
   });
   socket.on('data', (in_data) => {
     socket.end();
     socket.destroy();
     socket.unref();
-    console.log('tryConnect data for buffer ' + buffer.toString('hex'))
   });
   socket.on('error', (err) => {
     socket.destroy();
     socket.unref();
-    console.log('tryConnect with error ' + err +' for buffer ' + buffer.toString('hex'))
     if (attempt > 0) {
       setTimeout(() => {
         tryConnect(buffer, attempt - 1, waitMs * 2);


### PR DESCRIPTION
Node js function tryConnect() may receive EPIPE error even when data correctly sent to a pipe. 
To mitigate this a two way communication was added - "send registration" > "receive response" > "disconnect".  
Registration requests from osn continue to work correctly. 
