### PR TITLE
Revise initiating/finishing .dmp upload

### DIFF
--- a/crash-handler-process/platforms/process-osx.hpp
+++ b/crash-handler-process/platforms/process-osx.hpp
@@ -9,7 +9,9 @@ public:
     virtual int32_t  getPID(void)     override;
     virtual bool     isCritical(void) override;
     virtual bool     isAlive(void)    override;
-    virtual void     startMemoryDumpMonitoring(const std::wstring& eventName, const std::wstring& eventFinishedName, const std::wstring& dumpPath) override;
     virtual bool     isResponsive(void) override;
     virtual void     terminate(void)  override;
+    
+public:
+    virtual void     startMemoryDumpMonitoring(const std::wstring& eventName_Start, const std::wstring& eventName_Fail, const std::wstring& eventName_Success, const std::wstring& dumpPath, const std::wstring& dumpName) override;
 };

--- a/crash-handler-process/platforms/process-osx.mm
+++ b/crash-handler-process/platforms/process-osx.mm
@@ -27,7 +27,7 @@ bool Process_OSX::isCritical(void) {
 bool Process_OSX::isResponsive(void) {
 	return true; // check for responsiveness not impemented
 }
-void Process_OSX::startMemoryDumpMonitoring(const std::wstring& eventName, const std::wstring& eventFinishedName, const std::wstring& dumpPath) {
+void Process_OSX::startMemoryDumpMonitoring(const std::wstring& eventName_Start, const std::wstring& eventName_Fail, const std::wstring& eventName_Success, const std::wstring& dumpPath, const std::wstring& dumpName) {
 	return;
 }
 

--- a/crash-handler-process/platforms/process-win.hpp
+++ b/crash-handler-process/platforms/process-win.hpp
@@ -25,15 +25,18 @@
 
 class Process_WIN : public Process {
 private:
-	std::thread *checker;
-	std::thread *memorydump;
+	std::thread* checker{nullptr};
+	std::thread* memorydump{nullptr};
 	std::mutex mtx;
-	HANDLE hdl;
-	
-	HANDLE mds;  // Event set by crashed process to initiate memory dump
-	HANDLE mdf;  // Event to inform crashed process what memory dump finished
+
+	HANDLE handle_OpenProcess{INVALID_HANDLE_VALUE};	
+	HANDLE handle_event_Start{INVALID_HANDLE_VALUE};
+	HANDLE handle_event_Fail{INVALID_HANDLE_VALUE};
+	HANDLE handle_event_Success{INVALID_HANDLE_VALUE};
 
 	std::wstring memorydumpPath;
+	std::wstring memorydumpName;
+
 	HWND getTopWindow();
 
 public:
@@ -44,12 +47,16 @@ public:
     virtual int32_t  getPID(void)     override;
     virtual bool     isCritical(void) override;
     virtual bool     isAlive(void)    override;
-    virtual void     startMemoryDumpMonitoring(const std::wstring& eventName, const std::wstring& eventFinishedName, const std::wstring& dumpPath) override;
     virtual bool     isResponsive(void) override;
     virtual void     terminate(void)  override;
+	
+public:
+    virtual void     startMemoryDumpMonitoring(const std::wstring& eventName_Start, const std::wstring& eventName_Fail, const std::wstring& eventName_Success, const std::wstring& dumpPath, const std::wstring& dumpName) override;
 
 private:
     void worker();
     void memorydump_worker();
     DWORD getPIDDWORD();
+	static bool isValidHandleValue(const HANDLE h);
+	static void safeCloseHandle(HANDLE& h);
 };

--- a/crash-handler-process/process-manager.cpp
+++ b/crash-handler-process/process-manager.cpp
@@ -76,8 +76,8 @@ void ProcessManager::watcher_fnc() {
                 uint32_t pid = msg.readUInt32();
                 std::wstring eventName_Start = msg.readWstring();
                 std::wstring eventName_Fail = msg.readWstring();
-			    std::wstring eventName_Success = msg.readWstring();
-			    std::wstring dumpPath = msg.readWstring();
+                std::wstring eventName_Success = msg.readWstring();
+                std::wstring dumpPath = msg.readWstring();
                 std::wstring dumpName = msg.readWstring();
                 registerProcessMemoryDump(pid, eventName_Start, eventName_Fail, eventName_Success, dumpPath, dumpName);
                 break;

--- a/crash-handler-process/process-manager.cpp
+++ b/crash-handler-process/process-manager.cpp
@@ -60,7 +60,7 @@ void ProcessManager::watcher_fnc() {
             case Action::REGISTER: {
                 bool isCritical = msg.readBool();
                 uint32_t pid = msg.readUInt32();
-                size_t size = registerProcess(isCritical, (int32_t)pid);
+                size_t size = registerProcess(isCritical, pid);
 
                 if (size == 1)
                     startMonitoring();
@@ -74,11 +74,12 @@ void ProcessManager::watcher_fnc() {
             }
             case Action::REGISTERMEMORYDUMP: {
                 uint32_t pid = msg.readUInt32();
-                std::wstring eventName = msg.readWstring();
-                std::wstring eventFinishedName = msg.readWstring();
-                std::wstring dumpPath = msg.readWstring();
-
-                registerProcessMemoryDump((int32_t)pid, eventName, eventFinishedName, dumpPath);
+                std::wstring eventName_Start = msg.readWstring();
+                std::wstring eventName_Fail = msg.readWstring();
+			    std::wstring eventName_Success = msg.readWstring();
+			    std::wstring dumpPath = msg.readWstring();
+                std::wstring dumpName = msg.readWstring();
+                registerProcessMemoryDump(pid, eventName_Start, eventName_Fail, eventName_Success, dumpPath, dumpName);
                 break;
             }
             default:
@@ -203,7 +204,7 @@ void ProcessManager::unregisterProcess(uint32_t PID) {
     this->processes.erase(it);
 }
 
-void ProcessManager::registerProcessMemoryDump(uint32_t PID, const std::wstring& eventName, const std::wstring& eventFinishedName, const std::wstring& dumpPath) {
+void ProcessManager::registerProcessMemoryDump(uint32_t PID, const std::wstring& eventName_Start, const std::wstring& eventName_Fail, const std::wstring& eventName_Success, const std::wstring& dumpPath, const std::wstring& dumpName) {
     const std::lock_guard<std::mutex> lock(this->mtx);
 
     log_info << "requested memory dump on crash for pid = " << PID << std::endl;
@@ -218,7 +219,7 @@ void ProcessManager::registerProcessMemoryDump(uint32_t PID, const std::wstring&
         return;
 
     log_info << "register for memory dump" << std::endl;
-    (*it)->startMemoryDumpMonitoring(eventName, eventFinishedName, dumpPath);
+    (*it)->startMemoryDumpMonitoring(eventName_Start, eventName_Fail, eventName_Success, dumpPath, dumpName);
 }
 
 void ProcessManager::handleCrash(std::wstring path) {
@@ -262,8 +263,19 @@ void ProcessManager::sendExitMessage(bool appCrashed) {
 }
 
 void ProcessManager::terminateAll(void) {
-    for (auto & process : this->processes) 
-        process->terminate();
+
+    std::vector<std::thread> workers;
+
+    // What if the head process is busy? Do we really want the other processes to keep running?
+    // Instead, seperate these out into workers so that non-busy processes are killed asap
+    for (auto& process : this->processes) {
+		workers.push_back(std::thread([](Process* ptr) { ptr->terminate(); }, process.get()));
+	}
+     
+    for (auto& itr : workers) {
+		if (itr.joinable())
+			itr.join();
+    }
 }
 
 void ProcessManager::terminateNonCritical(void) {

--- a/crash-handler-process/process-manager.hpp
+++ b/crash-handler-process/process-manager.hpp
@@ -61,7 +61,7 @@ private:
 
     size_t registerProcess(bool isCritical, uint32_t PID);
     void unregisterProcess(uint32_t PID);
-    void registerProcessMemoryDump(uint32_t PID, const std::wstring& eventName, const std::wstring& eventFinishedName, const std::wstring& dumpPath);
+    void registerProcessMemoryDump(uint32_t PID, const std::wstring& eventName_Start, const std::wstring& eventName_Fail, const std::wstring& eventName_Success, const std::wstring& dumpPath, const std::wstring& dumpName);
 
     void terminateAll(void);
     void terminateNonCritical(void);

--- a/crash-handler-process/process.hpp
+++ b/crash-handler-process/process.hpp
@@ -37,12 +37,15 @@ protected:
 	int32_t  PID = 0;
 	bool     critical = false;
 	bool     alive = false;
+	bool     recievedDmpEvent = false;
 
 public:
 	virtual int32_t  getPID(void)     = 0;
 	virtual bool     isCritical(void) = 0;
-	virtual void     startMemoryDumpMonitoring(const std::wstring& eventName, const std::wstring& eventFinishedName, const std::wstring& dumpPath) = 0;
 	virtual bool     isAlive(void)    = 0;
     virtual bool     isResponsive(void) = 0;
-    virtual void     terminate(void)  = 0;
+	virtual void     terminate(void)    = 0;
+
+public:
+	virtual void     startMemoryDumpMonitoring(const std::wstring& eventName_Start, const std::wstring& eventName_Fail, const std::wstring& eventName_Success, const std::wstring& dumpPath, const std::wstring& dumpName) = 0;
 };


### PR DESCRIPTION
This commit is dependent on a corresponding update to obs-studio-node
https://github.com/stream-labs/obs-studio-node/tree/sentry-memorydmps

- Use a separate event for either Success/Failure of upload
- Accepts dumpName as input, no longer generate on our own
- Rename some variables for readability
- Add some comments to document tricky paths of execution