### PR TITLE
Make use of SetUnhandledExceptionFilter

### DIFF
--- a/crash-handler-process/logger.cpp
+++ b/crash-handler-process/logger.cpp
@@ -35,6 +35,7 @@
 
 bool log_output_working = false;
 
+std::wstring log_output_path;
 std::ofstream log_output_file;
 static int pid = 0;
 
@@ -102,6 +103,8 @@ void logging_start(std::wstring & log_path)
 			std::cout << "Failed to open log file, error = " << strerror(errno) << std::endl; 
 		}
 	}
+
+	log_output_path = log_path;
 }
 
 void logging_end()

--- a/crash-handler-process/logger.hpp
+++ b/crash-handler-process/logger.hpp
@@ -25,6 +25,7 @@
 
 const std::string getTimeStamp();
 
+extern std::wstring log_output_path;
 extern std::ofstream log_output_file;
 extern bool log_output_working;
 


### PR DESCRIPTION
Logs the event, cleans up and writes a minimalist .dmp to the cache directory

Example:
`https://user-images.githubusercontent.com/6963572/136632162-c5d00fec-cf94-46fb-91ff-f95812cbfc5d.png`
