### PR TITLE
Remove redistributable dll's from crash-handler

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,9 +55,6 @@ jobs:
 
   - script: 'cmake --build %SLBuildDirectory% --target install --config RelWithDebInfo'
     displayName: 'Build crash-handler'
-
-  - script: ./ci/copy-dependencies.cmd
-    displayName: 'Copy necessary dll files'
     
   - powershell: git clone https://github.com/stream-labs/symsrv-scripts.git
     displayName: 'Fetch symsrv-scripts'

--- a/ci/copy-dependencies.cmd
+++ b/ci/copy-dependencies.cmd
@@ -1,8 +1,0 @@
-copy "C:\Windows\System32\msvcp140.dll" "%FullDistributePath%\crash-handler\"
-copy "C:\Windows\System32\vcruntime140.dll" "%FullDistributePath%\crash-handler\"
-copy "C:\Windows\System32\vcruntime140_1.dll" "%FullDistributePath%\crash-handler\"
-
-copy "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x64\api-ms-win-crt-heap-l1-1-0.dll" "%FullDistributePath%\crash-handler\"
-copy "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x64\api-ms-win-crt-multibyte-l1-1-0.dll" "%FullDistributePath%\crash-handler\"
-copy "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x64\api-ms-win-crt-runtime-l1-1-0.dll" "%FullDistributePath%\crash-handler\"
-copy "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x64\api-ms-win-crt-string-l1-1-0.dll" "%FullDistributePath%\crash-handler\"


### PR DESCRIPTION
Instead, the installer and updater now both install VC_redist.x64