### PR TITLE
Use events to exit from threads faster

### DIFF
--- a/crash-handler-process/platforms/process-osx.hpp
+++ b/crash-handler-process/platforms/process-osx.hpp
@@ -14,4 +14,5 @@ public:
     
 public:
     virtual void     startMemoryDumpMonitoring(const std::wstring& eventName_Start, const std::wstring& eventName_Fail, const std::wstring& eventName_Success, const std::wstring& dumpPath, const std::wstring& dumpName) override;
+    virtual void     stopMemoryDumpMonitoring() override;
 };

--- a/crash-handler-process/platforms/process-osx.mm
+++ b/crash-handler-process/platforms/process-osx.mm
@@ -30,6 +30,9 @@ bool Process_OSX::isResponsive(void) {
 void Process_OSX::startMemoryDumpMonitoring(const std::wstring& eventName_Start, const std::wstring& eventName_Fail, const std::wstring& eventName_Success, const std::wstring& dumpPath, const std::wstring& dumpName) {
 	return;
 }
+void Process_OSX::stopMemoryDumpMonitoring() {
+	return;
+}
 
 bool Process_OSX::isAlive(void) {
 	struct proc_bsdinfo proc;

--- a/crash-handler-process/platforms/process-win.cpp
+++ b/crash-handler-process/platforms/process-win.cpp
@@ -124,9 +124,12 @@ void Process_WIN::startMemoryDumpMonitoring(const std::wstring& eventName_Start,
 
 void Process_WIN::memorydump_worker() {
 	log_info << "Memory dump worker started" << std::endl;
-	HANDLE handles[] = { handle_OpenProcess, handle_event_Start, handle_event_StopMonitoring};
+	HANDLE handles[] = { handle_OpenProcess, handle_event_Start, handle_event_StopMonitoring };
 	DWORD ret = WaitForMultipleObjects(3, handles, FALSE, INFINITE);
-	if (ret - WAIT_OBJECT_0 == 1) {
+	if ((ret - WAIT_OBJECT_0) == 2 || (ret - WAIT_OBJECT_0) == 0) {
+		safeCloseHandle(handle_event_Success);
+		SetEvent(handle_event_Fail);
+	} else if (ret - WAIT_OBJECT_0 == 1) {
 		recievedDmpEvent = true;
 		alive = false;
 		log_info << "Memory dump worker event recieved" << std::endl;

--- a/crash-handler-process/platforms/process-win.hpp
+++ b/crash-handler-process/platforms/process-win.hpp
@@ -33,6 +33,7 @@ private:
 	HANDLE handle_event_Start{INVALID_HANDLE_VALUE};
 	HANDLE handle_event_Fail{INVALID_HANDLE_VALUE};
 	HANDLE handle_event_Success{INVALID_HANDLE_VALUE};
+	HANDLE handle_event_StopMonitoring{INVALID_HANDLE_VALUE};
 
 	std::wstring memorydumpPath;
 	std::wstring memorydumpName;
@@ -52,6 +53,7 @@ public:
 	
 public:
     virtual void     startMemoryDumpMonitoring(const std::wstring& eventName_Start, const std::wstring& eventName_Fail, const std::wstring& eventName_Success, const std::wstring& dumpPath, const std::wstring& dumpName) override;
+    virtual void     stopMemoryDumpMonitoring() override;
 
 private:
     void worker();

--- a/crash-handler-process/process-manager.hpp
+++ b/crash-handler-process/process-manager.hpp
@@ -25,13 +25,14 @@
 #include "logger.hpp"
 #include "util.hpp"
 
-using stopper = std::atomic<bool>;
-
 struct ThreadData {
     bool         isRunnning = false;
-    stopper      stop = { false };
-    std::mutex*  mtx = nullptr;
+    std::mutex   mtx;
     std::thread* worker = nullptr;
+
+    bool         should_stop = false;
+    std::condition_variable stop_event;
+    std::mutex   stop_mutex;
 };
 
 class ProcessManager {

--- a/crash-handler-process/process-manager.hpp
+++ b/crash-handler-process/process-manager.hpp
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <thread>
 #include <atomic>
+#include <condition_variable>
 
 #include "socket.hpp"
 #include "process.hpp"
@@ -26,13 +27,13 @@
 #include "util.hpp"
 
 struct ThreadData {
-    bool         isRunnning = false;
-    std::mutex   mtx;
     std::thread* worker = nullptr;
 
-    bool         should_stop = false;
-    std::condition_variable stop_event;
-    std::mutex   stop_mutex;
+    bool should_stop = false;
+    std::condition_variable_any stop_event;
+    std::recursive_mutex stop_mutex;
+    void send_stop();
+    bool wait_or_stop();
 };
 
 class ProcessManager {

--- a/crash-handler-process/process.hpp
+++ b/crash-handler-process/process.hpp
@@ -43,9 +43,10 @@ public:
 	virtual int32_t  getPID(void)     = 0;
 	virtual bool     isCritical(void) = 0;
 	virtual bool     isAlive(void)    = 0;
-    virtual bool     isResponsive(void) = 0;
+	virtual bool     isResponsive(void) = 0;
 	virtual void     terminate(void)    = 0;
 
 public:
 	virtual void     startMemoryDumpMonitoring(const std::wstring& eventName_Start, const std::wstring& eventName_Fail, const std::wstring& eventName_Success, const std::wstring& dumpPath, const std::wstring& dumpName) = 0;
+	virtual void     stopMemoryDumpMonitoring() = 0;
 };


### PR DESCRIPTION
Use events to exit from threads faster than waiting for a sleep to finish or for a process to close. 