### PR TITLE
do not let override detected critical crash flag

### DIFF
--- a/crash-handler-process/process-manager.cpp
+++ b/crash-handler-process/process-manager.cpp
@@ -108,7 +108,7 @@ void ProcessManager::monitor_fnc() {
                     log_info << "process.pid: " << process->getPID() << std::endl;
                     log_info << "process.isCritical: " << process->isCritical() << std::endl;
 
-                    m_criticalCrash = process->isCritical();
+                    m_criticalCrash |= process->isCritical();
                     m_applicationCrashed = this->monitor->stop = true;
                 } else if (last_responsive_check == 0) {
                     detectedUnresponsive |= process->isResponsive();


### PR DESCRIPTION
In some crashes both electron and obs64 processes be dead at the moment when we check them. 
There was a bug what let override of detected critical crash be overwritten by dead non critical process.  