### PR TITLE
Fixed macOS blocking open which prevented process exit

### DIFF
--- a/crash-handler-process/platforms/socket-osx.cpp
+++ b/crash-handler-process/platforms/socket-osx.cpp
@@ -34,7 +34,7 @@ std::vector<char> Socket_OSX::read()
 	// It emulates the Windows implementation behavior.
 
 	std::vector<char> buffer;
-	int file_descriptor = open(this->name.c_str(), O_RDONLY|O_NONBLOCK);
+	int file_descriptor = open(this->name.c_str(), O_RDONLY | O_NONBLOCK);
 	if (file_descriptor < 0) {
 		log_info << "Could not open; |open| error: " << strerror(errno) << std::endl;
 		return buffer;

--- a/crash-handler-process/platforms/socket-osx.cpp
+++ b/crash-handler-process/platforms/socket-osx.cpp
@@ -28,16 +28,40 @@ std::unique_ptr<Socket> Socket::create()
 
 std::vector<char> Socket_OSX::read()
 {
+	// Previously, |open| blocked if there was not any data.
+	// So the process did not exit when it had to.
+	// The workaround is O_NONBLOCK + select + 500 ms timeout.
+	// It emulates the Windows implementation behavior.
+
 	std::vector<char> buffer;
-	buffer.resize(30000, 0);
-	int file_descriptor = open(this->name.c_str(), O_RDONLY);
+	int file_descriptor = open(this->name.c_str(), O_RDONLY|O_NONBLOCK);
 	if (file_descriptor < 0) {
-		log_info << "Could not open " << strerror(errno) << std::endl;
+		log_info << "Could not open; |open| error: " << strerror(errno) << std::endl;
 		return buffer;
 	}
+
+	fd_set set;
+	FD_ZERO(&set);
+	FD_SET(file_descriptor, &set);
+
+	struct timeval timeout;
+	timeout.tv_sec = 0;
+	timeout.tv_usec = 500000; // 500 ms
+
+	int rv = select(file_descriptor + 1, &set, NULL, NULL, &timeout);
+	if (rv <= 0) {
+		if (rv < 0) {
+			log_info << "Could not open; |select| error: " << strerror(errno) << std::endl;
+		}
+		close(file_descriptor);
+		return buffer;
+	}
+
+	buffer.resize(30000, 0);
 	int bytes_read = ::read(file_descriptor, buffer.data(), buffer.size());
 	buffer.resize(bytes_read < 0 ? 0 : bytes_read);
 	close(file_descriptor);
+
 	return buffer;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Modified the macOS socket class behavior to not wait for the pipe open more than 500 ms. This simulates the Windows implementation behavior and allows the reading thread to check the stop flag/signal and exit when it is necessary.

### Motivation and Context
The non-modified **crash-handler-process** does not exit on macOS when the **Desktop** application exits or crashes. It stays in the memory forever. Every time when **Desktop** starts, a new forever crash-handler-process is spawned.

### How Has This Been Tested?
Tested that now it exits correctly when necessary and does not exit when it does not have to. Confirmed the correct execution code path with debug logs.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
