### PR TITLE
macOS static gettext 

### DIFF
--- a/crash-handler-process/CMakeLists.txt
+++ b/crash-handler-process/CMakeLists.txt
@@ -56,16 +56,24 @@ IF(WIN32)
 		"${PROJECT_SOURCE_DIR}/minizip/iowin32.c" "${PROJECT_SOURCE_DIR}/minizip/iowin32.h"
 	)
 ELSE(APPLE)
-	find_package(Intl)
-	find_package(Gettext)
 	SET(APPLE_SOURCE
 		"${PROJECT_SOURCE_DIR}/platforms/util-osx.mm"
 		"${PROJECT_SOURCE_DIR}/platforms/socket-osx.cpp" "${PROJECT_SOURCE_DIR}/platforms/socket-osx.hpp"
 		"${PROJECT_SOURCE_DIR}/platforms/process-osx.mm" "${PROJECT_SOURCE_DIR}/platforms/process-osx.hpp"
 
 	)
-	include_directories(${Intl_INCLUDE_DIR})
 	find_library(COCOA Cocoa)
+	# Prepare gettext
+	FetchContent_Declare(
+		gettext
+		URL "https://obs-studio-deployment.s3.us-west-2.amazonaws.com/gettext-release-0.21.1-osx-x86_64.zip"
+		URL_HASH SHA256=ec744c179637005e0e9d45c863c5311affc7eed87d04bc817580d0704d2f7455)
+	FetchContent_MakeAvailable(gettext)		
+	SET(gettext_INCLUDE_DIR ${CMAKE_BINARY_DIR}/_deps/gettext-src/include)
+	SET(gettext_LIBRARIES
+		${CMAKE_BINARY_DIR}/_deps/gettext-src/lib/libintl.a
+		libiconv.a) # libiconv.a is available on macOS; the gettext package was compiled with the default libiconv.a
+	include_directories(${gettext_INCLUDE_DIR})
 ENDIF()
 
 
@@ -147,7 +155,7 @@ IF(WIN32)
 
 	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${deps_checker_SOURCE_DIR}/check_dependencies.cmd $<TARGET_FILE:crash-handler-process> ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR} $<CONFIG> )
 ELSE()
-	target_link_libraries(crash-handler-process ${COCOA} ${Intl_LIBRARIES})
+	target_link_libraries(crash-handler-process ${COCOA} ${gettext_LIBRARIES})
 ENDIF()
 
 message(status "${CMAKE_CURRENT_BINARY_DIR}/locale/")


### PR DESCRIPTION
### Description
- Compiled a static gettext package (include, lib, etc)
- Added downloading and using the package into the **crash-handler-process** `CMakeLists.txt`

### Motivation and Context
Currently, **crash-process-handler** does not work on macOS. 
```
sl-desktop-test/desktop/node_modules/crash-handler>./crash-handler-process 
dyld[27541]: Library not loaded: '/usr/local/opt/gettext/lib/libintl.8.dylib'
  Referenced from: '/Users/eugen/devel/sl-desktop-test/desktop/node_modules/crash-handler/crash-handler-process'
  Reason: tried: '/usr/local/opt/gettext/lib/libintl.8.dylib' (no such file), '/usr/local/lib/libintl.8.dylib' (no such file), '/usr/lib/libintl.8.dylib' (no such file)
```

### How Has This Been Tested?
- Tested compilation
- Tested that crash-handler-process starts
- Tested its dependencies. Now it does not require the `dylib`.

> >otool -L crash-handler-process
> crash-handler-process:
> 	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 23.0.0)
> 	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2022.44.149)
> 	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1775.118.101)
> 	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1775.118.101)
> 	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
> 	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 905.6.0)
> 	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.100.5)
> 	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
