### PR TITLE
Removed test source code

### DIFF
--- a/crash-handler-process/platforms/util-osx.mm
+++ b/crash-handler-process/platforms/util-osx.mm
@@ -113,15 +113,4 @@ void Util::setupLocale()
 	if (current_locale == nullptr || std::strlen(current_locale) == 0) {
 		setlocale(LC_ALL, "en_US.UTF-8");
 	}
-	setlocale(LC_ALL, "ru_RU.UTF-8");
-	bindtextdomain("messages", "/Users/vladimirsumarov/work/repos/streamlabs-obs/node_modules/crash-handler/locale");
-
-	std::string pwd = std::getenv("PWD");
-
-	std::ofstream testfile;
-	testfile.open("/Users/vladimirsumarov/work/repos/crash-handler/build/gettext.txt");
-	testfile << "test" << std::endl;
-	testfile << pwd << std::endl;
-	testfile << "testend" << std::endl;
-	testfile.close();
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Removed some source code which was used for testing.

### Motivation and Context
`std::string pwd = std::getenv("PWD");` caused a crash when Desktop was started as a macOS desktop app.

### How Has This Been Tested?
- Run `yarn package:mac`
- Start **Streamlabs Desktop** from `desktop/dist/mac`

The app does not crash without the test code.

### Types of changes
- Bug fix

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
