### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   clang-format-check:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/streamlabs/crash-handler/security/code-scanning/3](https://github.com/streamlabs/crash-handler/security/code-scanning/3)

To fix this issue, explicitly set the `permissions` block in the workflow, granting the least possible privilege needed to perform the formatting checks. In this case, since the workflow does not push, comment, or perform any write actions, only minimal read access to the repository contents is needed. Insert `permissions: contents: read` either at the root (applies to all jobs) or at the job level (specific to this job). In this solution, we will add the block at the job level for `clang-format-check` on line 13 so it is clear and contained.

**What to do:**  
Edit `.github/workflows/clang-format.yml`, adding the following under the job definition (`jobs: clang-format-check:`), before `runs-on: ubuntu-22.04`:  
```yaml
permissions:
  contents: read
```
No other changes or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
