### PR TITLE
run exe to show UI / Add hyperlink

### DIFF
--- a/crash-handler-process/locale/ar_SA/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/ar_SA/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Arabic\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -24,24 +24,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -50,60 +50,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -111,28 +111,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/cs_CZ/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/cs_CZ/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Czech\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -25,24 +25,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -51,60 +51,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -112,28 +112,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/da_DK/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/da_DK/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Danish\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -25,24 +25,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -51,60 +51,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -112,28 +112,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/de_DE/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/de_DE/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: German\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -28,7 +28,7 @@ msgstr ""
 "immer noch im Hintergrund."
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -37,21 +37,21 @@ msgstr ""
 "wird jedoch Ihr Stream/Ihre Aufzeichnung beendet."
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 "Klicken Sie auf die Schaltfläche Ja, um das Streaming/die Aufzeichnung "
 "fortzusetzen."
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 "Klicken Sie auf die Schaltfläche Nein, um das Streaming/die Aufzeichnung zu "
 "beenden."
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "Nein"
 
@@ -60,12 +60,12 @@ msgid "YES"
 msgstr "JA"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "OK"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -75,48 +75,48 @@ msgstr ""
 "ausgeführt. Wenn Sie bereit sind, klicken Sie unten auf die Schaltfläche OK, "
 "um den Stream/die Aufzeichnung zu beenden und die Anwendung neu zu starten."
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "Ein Fehler ist aufgetreten"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "Neustart wählen"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -124,29 +124,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/en_US/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/en_US/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: English\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -25,24 +25,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -51,60 +51,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "An error occurred"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -112,28 +112,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/es_ES/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/es_ES/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -28,7 +28,7 @@ msgstr ""
 "continúa en segundo plano."
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -37,17 +37,17 @@ msgstr ""
 "sesión de streaming/grabación."
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr "Haga clic en el botón Sí para seguir haciendo streaming/grabando."
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr "Haga clic en el botón No para detener el stream/la grabación."
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "No"
 
@@ -56,12 +56,12 @@ msgid "YES"
 msgstr "SÍ"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "Aceptar"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -71,48 +71,48 @@ msgstr ""
 "Cuando quiera, haga clic en el botón Aceptar para terminar su sesión de "
 "streaming/grabación y reiniciar la aplicación."
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "Se ha producido un error."
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "Elija cuándo reiniciar"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -120,29 +120,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/fr_FR/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: French\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -28,7 +28,7 @@ msgstr ""
 "produit toujours en arrière-plan."
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -37,17 +37,17 @@ msgstr ""
 "mettra fin à votre session de streaming/d'enregistrement."
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr "Cliquez sur le bouton Oui pour continuer à streamer/enregistrer."
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr "Cliquez sur le bouton Non pour arrêter le streaming/l'enregistrement."
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "Non"
 
@@ -56,12 +56,12 @@ msgid "YES"
 msgstr "OUI"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "OK"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -72,48 +72,48 @@ msgstr ""
 "OK ci-dessous pour terminer votre streaming/enregistrement et relancer "
 "l'application."
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "Une erreur est survenue"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "Choisissez lorsque vous souhaitez redémarrer"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -121,29 +121,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/hu_HU/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/hu_HU/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Hungarian\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -25,24 +25,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -51,60 +51,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -112,28 +112,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/id_ID/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/id_ID/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Indonesian\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -24,24 +24,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -50,60 +50,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -111,28 +111,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/it_IT/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/it_IT/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Italian\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -28,7 +28,7 @@ msgstr ""
 "operazione continua a essere eseguita in background."
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -37,20 +37,20 @@ msgstr ""
 "streaming/registrazione terminerà."
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 "Fai clic sul pulsante Sì per continuare a trasmettere in streaming/"
 "registrare."
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 "Fai clic sul pulsante No per interrompere lo streaming/la registrazione."
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "No"
 
@@ -59,12 +59,12 @@ msgid "YES"
 msgstr "SÌ"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "OK"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -74,48 +74,48 @@ msgstr ""
 "Quando possibile, fai clic sul pulsante OK in basso per terminare lo "
 "streaming/la registrazione e riavviare l'applicazione."
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "Si è verificato un errore"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "Scegli quando riavviare"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -123,29 +123,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/ja_JP/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/ja_JP/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Japanese\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -28,7 +28,7 @@ msgstr ""
 "います。"
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -37,17 +37,17 @@ msgstr ""
 "リーム/録画セッションが終了します。"
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr "ストリーミング/録画を続行するには、[はい] ボタンをクリックします。"
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr "ストリーミング/録画を停止するには、[いいえ] ボタンをクリックします。"
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "いいえ"
 
@@ -56,12 +56,12 @@ msgid "YES"
 msgstr "はい"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "OK"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -71,48 +71,48 @@ msgstr ""
 "下の [OK] ボタンをクリックしてストリーム/録画を終了し、アプリケーションを再起"
 "動してください。"
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "エラーが発生しました"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "再起動するタイミングを選択"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -120,29 +120,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/ko_KR/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/ko_KR/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Korean\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -25,24 +25,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -51,60 +51,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -112,28 +112,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/mk_MK/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/mk_MK/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Macedonian\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -24,24 +24,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -50,60 +50,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -111,28 +111,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/nl_NL/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/nl_NL/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Dutch\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -28,7 +28,7 @@ msgstr ""
 "de achtergrond plaats."
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -37,17 +37,17 @@ msgstr ""
 "je stream-/opnamesessie echter beëindigd."
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr "Klik op de knop Ja om door te gaan met streamen/opnemen."
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr "Klik op de knop Nee om het streamen/opnemen te stoppen."
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "Nee"
 
@@ -56,12 +56,12 @@ msgid "YES"
 msgstr "JA"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "OK"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -71,48 +71,48 @@ msgstr ""
 "je klaar bent, klik je op de knop OK hieronder om je stream/opname te "
 "beëindigen en de applicatie opnieuw te starten."
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "Er is een fout opgetreden"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "Kies wanneer je opnieuw wilt opstarten"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -120,29 +120,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/pl_PL/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/pl_PL/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Polish\n"
@@ -18,7 +18,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -28,7 +28,7 @@ msgstr ""
 "się! Jeśli streamowałeś lub nagrywałeś, to nadal dzieje się to w tle. "
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -37,17 +37,17 @@ msgstr ""
 "zakończy Twoją sesję streamowania / nagrywania."
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr "Kliknij przycisk Tak, aby kontynuować streamowanie / nagrywanie."
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr "Kliknij przycisk Nie, aby zatrzymać streamowanie / nagrywanie."
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "Nie"
 
@@ -56,12 +56,12 @@ msgid "YES"
 msgstr "TAK"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "OK"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -71,48 +71,48 @@ msgstr ""
 "będziesz gotowy, kliknij przycisk OK poniżej, aby zakończyć streamowanie / "
 "nagrywanie i ponownie uruchomić aplikację."
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "Wystąpił błąd"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "Wybierz, kiedy uruchomić ponownie"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -120,29 +120,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/pt_BR/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/pt_BR/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -28,7 +28,7 @@ msgstr ""
 "acontecendo em segundo plano."
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -37,17 +37,17 @@ msgstr ""
 "sua sessão de transmissão/gravação."
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr "Clique no botão Sim para continuar a transmissão/gravação."
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr "Clique no botão Não para interromper a transmissão/gravação."
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "Não"
 
@@ -56,12 +56,12 @@ msgid "YES"
 msgstr "SIM"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "Ok"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -71,48 +71,48 @@ msgstr ""
 "plano. Quando estiver pronto, clique no botão OK abaixo para encerrar sua "
 "transmissão/gravação e reinicie o aplicativo."
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "Ocorreu um erro"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "Escolha quando reiniciar"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -120,29 +120,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/pt_PT/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/pt_PT/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Portuguese\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -28,7 +28,7 @@ msgstr ""
 "segundo plano."
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -37,17 +37,17 @@ msgstr ""
 "irá encerrar a sua sessão de transmissão/gravação."
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr "Clique no botão Sim para continuar a transmitir/gravar."
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr "Clique no botão Não para parar a transmissão/gravação."
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "Não"
 
@@ -56,12 +56,12 @@ msgid "YES"
 msgstr "SIM"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "OK"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -71,48 +71,48 @@ msgstr ""
 "plano. Quando estiver pronto, clique no botão OK abaixo para terminar a sua "
 "transmissão/gravação e reiniciar a aplicação."
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "Ocorreu um erro"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "Escolher quando pretende reiniciar"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -120,29 +120,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/ru_RU/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/ru_RU/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Russian\n"
@@ -18,7 +18,7 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -29,7 +29,7 @@ msgstr ""
 "продолжается в фоновом режиме."
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -38,17 +38,17 @@ msgstr ""
 "трансляция / запись при этом завершится."
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr "Нажмите кнопку «Да», чтобы продолжить трансляцию / запись."
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr "Нажмите кнопку «Нет», чтобы остановить трансляцию / запись."
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "Нет"
 
@@ -57,12 +57,12 @@ msgid "YES"
 msgstr "ДА"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "ОК"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -72,48 +72,48 @@ msgstr ""
 "нажмите кнопку «ОК» ниже, чтобы завершить трансляцию / запись и "
 "перезапустить приложение."
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "Произошла ошибка"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "Перезапустите трансляцию / запись, когда вам будет удобно"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -121,29 +121,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/sk_SK/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/sk_SK/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Slovak\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -25,24 +25,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -51,60 +51,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -112,28 +112,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/sl_SI/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/sl_SI/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Slovenian\n"
@@ -18,7 +18,7 @@ msgstr ""
 "%100==4 ? 2 : 3);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -26,24 +26,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -52,60 +52,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -113,28 +113,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/sv_SE/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/sv_SE/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Swedish\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -25,24 +25,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -51,60 +51,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -112,28 +112,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/th_TH/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/th_TH/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Thai\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -24,24 +24,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -50,60 +50,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -111,28 +111,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/tr_TR/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/tr_TR/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Turkish\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -28,7 +28,7 @@ msgstr ""
 "varsa işlem, arka planda devam etmektedir."
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -37,17 +37,17 @@ msgstr ""
 "başlatıldığında yayın/kayıt oturumu sona erer."
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr "Yayın/kayıt işlemine devam etmek için Evet düğmesine tıklayın."
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr "Yayın/kayıt işlemini durdurmak için Hayır düğmesine tıklayın."
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "Hayır"
 
@@ -56,12 +56,12 @@ msgid "YES"
 msgstr "EVET"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "Tamam"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -71,48 +71,48 @@ msgstr ""
 "yayın/kayıt işleminizi sonlandırmak ve uygulamayı yeniden başlatmak için "
 "Tamam düğmesine tıklayın."
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "Bir hata oluştu"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "Ne zaman yeniden başlatılacağını seçin"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -120,29 +120,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/vi_VN/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/vi_VN/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Vietnamese\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -25,24 +25,24 @@ msgid ""
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr ""
 
@@ -51,60 +51,60 @@ msgid "YES"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr ""
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
 "relaunch the application."
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr ""
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -112,28 +112,32 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""

--- a/crash-handler-process/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/zh_CN/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Chinese (simplified)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -26,7 +26,7 @@ msgstr ""
 "在后台进行。"
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -34,17 +34,17 @@ msgstr ""
 "只要您准备就绪，我们就可以重新启动应用程序，但这将结束您的直播/录制会话。"
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr "点击“是”以继续直播/录制。"
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr "点击“否”以停止直播/录制。"
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "否"
 
@@ -53,12 +53,12 @@ msgid "YES"
 msgstr "是"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "确定"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -67,48 +67,48 @@ msgstr ""
 "您的直播/录制会话仍在后台运行。准备就绪后，请点击下方的“确定”按钮结束直播/录"
 "制并重新启动应用程序。"
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "发生错误"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "选择重新启动的时间"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -116,29 +116,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/locale/zh_TW/LC_MESSAGES/messages.po
+++ b/crash-handler-process/locale/zh_TW/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-28 12:07-0800\n"
+"POT-Creation-Date: 2026-02-02 17:47-0600\n"
 "PO-Revision-Date: 2022-09-03 12:16-0700\n"
 "Last-Translator: <EMAIL@ADDRESS>\n"
 "Language-Team: Chinese (traditional)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: crash-handler-process\platforms\util-osx.mm:31
-#: crash-handler-process\platforms\util-win.cpp:116
+#: crash-handler-process\platforms\util-win.cpp:119
 msgid ""
 "An error occurred which has caused Streamlabs Desktop to close. Don't worry! "
 "If you were streaming or recording, that is still happening in the "
@@ -26,7 +26,7 @@ msgstr ""
 "仍會在背景進行。"
 
 #: crash-handler-process\platforms\util-osx.mm:33
-#: crash-handler-process\platforms\util-win.cpp:119
+#: crash-handler-process\platforms\util-win.cpp:122
 msgid ""
 "Whenever you're ready, we can relaunch the application, however this will "
 "end your stream / recording session."
@@ -34,17 +34,17 @@ msgstr ""
 "只要您準備好，我們就可以重新啟動應用程式，但這會結束您的直播/錄製工作。"
 
 #: crash-handler-process\platforms\util-osx.mm:35
-#: crash-handler-process\platforms\util-win.cpp:122
+#: crash-handler-process\platforms\util-win.cpp:125
 msgid "Click the Yes button to keep streaming / recording."
 msgstr "按一下「是」按鈕可繼續進行直播/錄製。"
 
 #: crash-handler-process\platforms\util-osx.mm:36
-#: crash-handler-process\platforms\util-win.cpp:124
+#: crash-handler-process\platforms\util-win.cpp:127
 msgid "Click the No button to stop streaming / recording."
 msgstr "按一下「否」按鈕可停止直播/錄製。"
 
 #: crash-handler-process\platforms\util-osx.mm:39
-#: crash-handler-process\platforms\upload-window-win.cpp:402
+#: crash-handler-process\platforms\upload-window-win.cpp:429
 msgid "No"
 msgstr "否"
 
@@ -53,12 +53,12 @@ msgid "YES"
 msgstr "是"
 
 #: crash-handler-process\platforms\util-osx.mm:50
-#: crash-handler-process\platforms\upload-window-win.cpp:404
+#: crash-handler-process\platforms\upload-window-win.cpp:431
 msgid "OK"
 msgstr "確定"
 
 #: crash-handler-process\platforms\util-osx.mm:51
-#: crash-handler-process\platforms\util-win.cpp:133
+#: crash-handler-process\platforms\util-win.cpp:136
 msgid ""
 "Your stream / recording session is still running in the background. Whenever "
 "you're ready, click the OK button below to end your stream / recording and "
@@ -67,48 +67,48 @@ msgstr ""
 "您的直播/錄製工作仍會在背景進行。在您準備就緒後，按一下下方的「確定」按鈕以結"
 "束您的直播/錄製，然後重新啟動應用程式。"
 
-#: crash-handler-process\platforms\util-win.cpp:114
+#: crash-handler-process\platforms\util-win.cpp:117
 msgid "An error occurred"
 msgstr "發生錯誤"
 
-#: crash-handler-process\platforms\util-win.cpp:132
+#: crash-handler-process\platforms\util-win.cpp:135
 msgid "Choose when to restart"
 msgstr "選擇何時重新啟動"
 
-#: crash-handler-process\platforms\upload-window-win.cpp:111
+#: crash-handler-process\platforms\upload-window-win.cpp:112
 msgid "The application just crashed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:112
+#: crash-handler-process\platforms\upload-window-win.cpp:113
 msgid "Would you like to send a report to the developers?"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:127
+#: crash-handler-process\platforms\upload-window-win.cpp:129
 #, c-format
 msgid ""
 "Uploading... %.2f%%\r\n"
 "%.1f / %.1fmb"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:134
+#: crash-handler-process\platforms\upload-window-win.cpp:136
 #, c-format
 msgid "Saving... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:143
+#: crash-handler-process\platforms\upload-window-win.cpp:145
 #, c-format
 msgid "Zipping... to \"%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:152
+#: crash-handler-process\platforms\upload-window-win.cpp:154
 msgid "Failed to save the local debug information."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:160
+#: crash-handler-process\platforms\upload-window-win.cpp:162
 msgid "Initializing upload..."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:167
+#: crash-handler-process\platforms\upload-window-win.cpp:169
 #, c-format
 msgid ""
 "Successfully uploaded the debug information.\r\n"
@@ -116,29 +116,33 @@ msgid ""
 "File: \"%s\"."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:178
+#: crash-handler-process\platforms\upload-window-win.cpp:180
 #, c-format
 msgid ""
 "Upload cancleled.\r\n"
 "%s removed."
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:186
+#: crash-handler-process\platforms\upload-window-win.cpp:188
 #, c-format
 msgid ""
 "Upload failed. Save a copy?\r\n"
 "\"%s/%s\""
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:374
+#: crash-handler-process\platforms\upload-window-win.cpp:392
 msgid "Streamlabs Desktop has encountered a critical error"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:401
+#: crash-handler-process\platforms\upload-window-win.cpp:422
+msgid "Troubleshoot here"
+msgstr ""
+
+#: crash-handler-process\platforms\upload-window-win.cpp:428
 msgid "Yes"
 msgstr ""
 
-#: crash-handler-process\platforms\upload-window-win.cpp:403
+#: crash-handler-process\platforms\upload-window-win.cpp:430
 msgid "Cancel"
 msgstr ""
 

--- a/crash-handler-process/main.cpp
+++ b/crash-handler-process/main.cpp
@@ -22,6 +22,7 @@
 #include <codecvt>
 
 #if defined(WIN32)
+#include "platforms/upload-window-win.hpp"
 const std::string log_file_name = "\\crash-handler.log";
 #else // for __APPLE__ and other
 const std::wstring log_file_name = L"/crash-handler.log";
@@ -51,6 +52,13 @@ int main(int argc, char **argv)
 	static thread_local std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
 
 	// Frontend passes as non-unicode
+	if (nArgs == 1) {
+		// No arguments - show the UI for development.
+		UploadWindow::getInstance()->createWindow();
+		UploadWindow::getInstance()->crashCaught();
+		UploadWindow::getInstance()->waitForUserChoise();
+		return 0;
+	}
 	if (nArgs >= 1)
 		path = szArglist[0];
 	if (nArgs >= 3)

--- a/crash-handler-process/platforms/upload-window-win.cpp
+++ b/crash-handler-process/platforms/upload-window-win.cpp
@@ -41,6 +41,7 @@ std::unique_ptr<UploadWindow> UploadWindow::instance = nullptr;
 #define CUSTOM_UPLOAD_CANCELED (WM_USER + 10)
 #define CUSTOM_ZIPPING_STARTED (WM_USER + 11)
 #define CUSTOM_REQUESTED_CLICK (WM_USER + 12)
+constexpr int IDC_HYPERLINK = 1001;
 
 std::wstring from_utf8_to_utf16_wide(const char *from, size_t length = -1);
 
@@ -119,6 +120,7 @@ LRESULT UploadWindow::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 		SendMessage(progresss_bar_hwnd, PBM_SETRANGE32, 0, 100);
 		SendMessage(progresss_bar_hwnd, PBM_SETPOS, 0, 0);
 		ShowWindow(progresss_bar_hwnd, SW_SHOW);
+		ShowWindow(hyperlink_hwnd, SW_SHOW);
 		break;
 	}
 	case CUSTOM_PROGRESS_MSG: {
@@ -219,6 +221,14 @@ LRESULT UploadWindow::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			upload_window_choose_variable.notify_one();
 			break;
 		}
+		// Extract notification code and control ID
+		int notificationCode = HIWORD(wParam);
+		int controlId = LOWORD(wParam);
+		if (controlId == IDC_HYPERLINK && notificationCode == STN_CLICKED) {
+			ShellExecuteW(nullptr, L"open", L"https://streamlabs.com/content-hub/post/streamlabs-desktop-crash-troubleshooting-guide", nullptr,
+				      nullptr, SW_SHOWNORMAL);
+			break;
+		}
 		break;
 	}
 	case CUSTOM_REQUESTED_CLICK: {
@@ -232,12 +242,21 @@ LRESULT UploadWindow::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 		}
 		break;
 	}
-	case WM_CTLCOLORSTATIC:
+	case WM_CTLCOLORSTATIC: {
+		if ((HWND)lParam == hyperlink_hwnd) {
+			HDC hdc = (HDC)wParam;
+			SetTextColor(hdc, RGB(0, 0, 255));
+			SetBkMode(hdc, TRANSPARENT);
+			return (LRESULT)GetStockObject(NULL_BRUSH);
+		}
+		[[fallthrough]];
+	}
 	case WM_CTLCOLOREDIT: {
 		if ((HWND)lParam == upload_label_hwnd) {
 			HDC hdc = (HDC)wParam;
 			return (LRESULT)GetStockObject(CTLCOLOR_MSGBOX);
 		}
+		break;
 	}
 	}
 
@@ -385,7 +404,7 @@ void UploadWindow::windowThread()
 	int x_pos = 10;
 	int y_pos = 10;
 	int x_size = 470;
-	int y_size = 250;
+	int y_size = height;
 	RECT client_rect;
 	if (GetClientRect(upload_window_hwnd, &client_rect)) {
 		x_size = client_rect.right - client_rect.left;
@@ -395,8 +414,15 @@ void UploadWindow::windowThread()
 	progresss_bar_hwnd = CreateWindow(PROGRESS_CLASS, TEXT("ProgressWorker"), WS_CHILD | PBS_SMOOTH, x_pos, y_pos, x_size - 20, 40, upload_window_hwnd,
 					  NULL, NULL, NULL);
 
-	upload_label_hwnd = CreateWindow(WC_EDIT, TEXT(""), WS_CHILD | WS_VISIBLE | ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN, x_pos, y_pos + 50,
-					 x_size - 20, 90, upload_window_hwnd, NULL, NULL, NULL);
+	const int label_height = 90;
+	const int label_ypos = y_pos + 50;
+	upload_label_hwnd = CreateWindow(WC_EDIT, TEXT(""), WS_CHILD | WS_VISIBLE | ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN, x_pos, label_ypos,
+					 x_size - 20, label_height, upload_window_hwnd, NULL, NULL, NULL);
+
+	std::wstring link_text = from_utf8_to_utf16_wide(boost::locale::translate("Troubleshoot here").str().c_str());
+	const HMENU hyperlinkId = reinterpret_cast<HMENU>(static_cast<INT_PTR>(IDC_HYPERLINK));
+	hyperlink_hwnd = CreateWindow(WC_STATIC, link_text.c_str(), SS_LEFT | WS_CHILD | SS_NOTIFY, x_pos, y_pos + (label_ypos + label_height), x_size - 20, 20,
+				      upload_window_hwnd, hyperlinkId, NULL, NULL);
 
 	std::wstring yes_button_title = from_utf8_to_utf16_wide(boost::locale::translate("Yes").str().c_str());
 	std::wstring no_button_title = from_utf8_to_utf16_wide(boost::locale::translate("No").str().c_str());
@@ -429,6 +455,11 @@ void UploadWindow::windowThread()
 		SendMessage(cancel_button_hwnd, WM_SETFONT, WPARAM(main_font), TRUE);
 		SendMessage(no_button_hwnd, WM_SETFONT, WPARAM(main_font), TRUE);
 	}
+	HFONT underline_font = CreateFont(0, 0, 0, 0, FW_NORMAL, FALSE, TRUE /* underline */, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+					  DEFAULT_QUALITY, DEFAULT_PITCH | FF_SWISS, L"Segoe UI");
+	if (hyperlink_hwnd && underline_font) {
+		SendMessage(hyperlink_hwnd, WM_SETFONT, WPARAM(underline_font), TRUE);
+	}
 	SendMessage(upload_label_hwnd, EM_SETREADONLY, TRUE, 0);
 
 	upload_window_choose_variable.notify_one();
@@ -442,7 +473,9 @@ void UploadWindow::windowThread()
 	if (main_font) {
 		DeleteObject(main_font);
 	}
-
+	if (underline_font) {
+		DeleteObject(underline_font);
+	}
 	log_info << "UploadWindow windowThread at finish" << std::endl;
 }
 

--- a/crash-handler-process/platforms/upload-window-win.hpp
+++ b/crash-handler-process/platforms/upload-window-win.hpp
@@ -81,8 +81,9 @@ private:
 	HWND yes_button_hwnd = NULL;
 	HWND cancel_button_hwnd = NULL;
 	HWND no_button_hwnd = NULL;
+	HWND hyperlink_hwnd = NULL;
 	int width = 500;
-	int height = 250;
+	int height = 300;
 
 	bool user_wants_to_close = false;
 	int button_clicked = 0;


### PR DESCRIPTION
* Now if exe is run without any args it will display the UI for local development
* Add "Troubleshoot here" hyperlink that takes user to a troubleshooting streamlabs desktop page

Image below shows the updated UI:
<img width="482" height="291" alt="image" src="https://github.com/user-attachments/assets/853ca1e9-8709-4d1b-875c-dd758e7fcd46" />

Before:
<img width="676" height="342" alt="image" src="https://github.com/user-attachments/assets/8ab71e62-cf84-4257-8718-19497384cb8e" />

## How was this tested? 
* Now you can view the UI from Visual Studio when you set "crash-handler-process" as default
* Also tested this change by causing a crash in Desktop and verified a crash report was uploaded to `obs.1770074735.5903Q6UR17ZX133.zip`
