### PR TITLE
Display Hand icon on hyperlink mouseover

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ set INSTALL_PACKAGE_PATH="../desktop/node_modules/crash-handler"
 cmake  -B"build" -G"Visual Studio 17 2022" -A x64  -DDepsPath="%CD%\build\deps\%BIN_DEPENDENCIES%\win64" -DBOOST_ROOT="%CD%\build\deps\boost"  -DCMAKE_INSTALL_PREFIX="%INSTALL_PACKAGE_PATH%"
 cmake --build "build" --target install --config RelWithDebInfo
 ```
-
+If the startup project is set to `crash-handler-process` and its run with no additional args then the UI will be displayed.
 ## On macOS
 ```
 yarn install

--- a/crash-handler-process/platforms/upload-window-win.cpp
+++ b/crash-handler-process/platforms/upload-window-win.cpp
@@ -103,6 +103,16 @@ LRESULT UploadWindow::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 		return DefWindowProc(hwnd, msg, wParam, lParam);
 
 	switch (msg) {
+	case WM_SETCURSOR: {
+		HWND hHover = (HWND)wParam;
+
+		if (hHover == hyperlink_hwnd) {
+			SetCursor(hand_cursor);
+			return TRUE;
+		}
+
+		break;
+	}
 	case CUSTOM_CLOSE_MSG:
 		log_info << "UploadWindow close message recieved" << std::endl;
 		DestroyWindow(upload_window_hwnd);
@@ -423,6 +433,7 @@ void UploadWindow::windowThread()
 	const HMENU hyperlinkId = reinterpret_cast<HMENU>(static_cast<INT_PTR>(IDC_HYPERLINK));
 	hyperlink_hwnd = CreateWindow(WC_STATIC, link_text.c_str(), SS_LEFT | WS_CHILD | SS_NOTIFY, x_pos, y_pos + (label_ypos + label_height), x_size - 20, 20,
 				      upload_window_hwnd, hyperlinkId, NULL, NULL);
+	hand_cursor = LoadCursor(nullptr, IDC_HAND);
 
 	std::wstring yes_button_title = from_utf8_to_utf16_wide(boost::locale::translate("Yes").str().c_str());
 	std::wstring no_button_title = from_utf8_to_utf16_wide(boost::locale::translate("No").str().c_str());

--- a/crash-handler-process/platforms/upload-window-win.hpp
+++ b/crash-handler-process/platforms/upload-window-win.hpp
@@ -82,6 +82,7 @@ private:
 	HWND cancel_button_hwnd = NULL;
 	HWND no_button_hwnd = NULL;
 	HWND hyperlink_hwnd = NULL;
+	HCURSOR hand_cursor = NULL;
 	int width = 500;
 	int height = 300;
 


### PR DESCRIPTION
Display a Hand icon so users know they can click on the hyperlink.
Related PR: https://github.com/streamlabs/crash-handler/pull/132

